### PR TITLE
add required JVM args for Loader to profile json

### DIFF
--- a/src/main/java/net/ornithemc/meta/web/ProfileHandlerV3.java
+++ b/src/main/java/net/ornithemc/meta/web/ProfileHandlerV3.java
@@ -172,11 +172,10 @@ public class ProfileHandlerV3 {
 		arguments.putArray("game");
 
 		if (generation >= 2) {
-			jvmArgs.add(info.getLoaderType().getSystemProperties().fixPackageAccess());
-			jvmArgs.add("true"); // not needed for FLoader, but QLoader requires the value to be true
+			// value not needed for FLoader, but QLoader requires the value to be true
+			jvmArgs.add(info.getLoaderType().getJvmArguments().fixPackageAccess(true));
 		}
-		jvmArgs.add(info.getLoaderType().getSystemProperties().gameVersion());
-		jvmArgs.add(info.getIntermediary().getVersion());
+		jvmArgs.add(info.getLoaderType().getJvmArguments().gameVersion(info.getGame(side)));
 
 		profile.set("arguments", arguments);
 

--- a/src/main/java/net/ornithemc/meta/web/models/JvmArguments.java
+++ b/src/main/java/net/ornithemc/meta/web/models/JvmArguments.java
@@ -18,21 +18,21 @@
 
 package net.ornithemc.meta.web.models;
 
-public class SystemProperties {
+public class JvmArguments {
 
 	String fixPackageAccess;
 	String gameVersion;
 
-	public SystemProperties(String fixPackageAccess, String gameVersion) {
+	public JvmArguments(String fixPackageAccess, String gameVersion) {
 		this.fixPackageAccess = fixPackageAccess;
 		this.gameVersion = gameVersion;
 	}
 
-	public String fixPackageAccess() {
-		return this.fixPackageAccess;
+	public String fixPackageAccess(boolean value) {
+		return this.fixPackageAccess + "=" + value;
 	}
 
-	public String gameVersion() {
-		return this.gameVersion;
+	public String gameVersion(String value) {
+		return this.gameVersion + "=" + value;
 	}
 }

--- a/src/main/java/net/ornithemc/meta/web/models/LoaderType.java
+++ b/src/main/java/net/ornithemc/meta/web/models/LoaderType.java
@@ -22,22 +22,22 @@ import net.ornithemc.meta.data.VersionDatabase;
 
 public enum LoaderType {
 
-	FABRIC("fabric", VersionDatabase.FABRIC_MAVEN_URL, new SystemProperties("-Dfabric.fixPackageAccess", "-Dfabric.gameVersion")),
-	QUILT("quilt", VersionDatabase.QUILT_MAVEN_URL, new SystemProperties("-Dloader.fixPackageAccess", "-Dloader.gameVersion")),
+	FABRIC("fabric", VersionDatabase.FABRIC_MAVEN_URL, new JvmArguments("-Dfabric.fixPackageAccess", "-Dfabric.gameVersion")),
+	QUILT("quilt", VersionDatabase.QUILT_MAVEN_URL, new JvmArguments("-Dloader.fixPackageAccess", "-Dloader.gameVersion")),
 	ORNITHE("ornithe", VersionDatabase.ORNITHE_MAVEN_URL);
 
 	private final String name;
 	private final String maven;
-	private final SystemProperties systemProperties;
+	private final JvmArguments jvmArguments;
 
 	private LoaderType(String name, String maven) {
-		this(name, maven, new SystemProperties(null, null));
+		this(name, maven, new JvmArguments(null, null));
 	}
 
-	private LoaderType(String name, String maven, SystemProperties systemProperties) {
+	private LoaderType(String name, String maven, JvmArguments jvmArguments) {
 		this.name = name;
 		this.maven = maven;
-		this.systemProperties = systemProperties;
+		this.jvmArguments = jvmArguments;
 	}
 
 	public String getName() {
@@ -48,7 +48,7 @@ public enum LoaderType {
 		return maven;
 	}
 
-	public SystemProperties getSystemProperties() {
-		return systemProperties;
+	public JvmArguments getJvmArguments() {
+		return jvmArguments;
 	}
 }


### PR DESCRIPTION
`-Dfabric.fixPackageAccess` is only required for gen2, since that intermediary enforces the target package which trips some versions up

`-Dfabric.gameVersion` is relevant for gen1 too, in order to make Infdev versions use the correct version